### PR TITLE
Don't use seconds in event editor.

### DIFF
--- a/Charm/EventEditor.cpp
+++ b/Charm/EventEditor.cpp
@@ -55,12 +55,11 @@ EventEditor::EventEditor( const Event& event, QWidget* parent )
     // a simple function to toggle 12h and 24h mode:
     // yeah, I know, this will survive changes in the user prefs, but
     // only for this instance of the edit dialog
-    QTimeEdit edit( this ); // this bugger is gone after the constructor
-    QString originalDateTimeFormat = edit.displayFormat();
+    const QString originalDateTimeFormat = m_ui->timeEditStart->displayFormat();
 
-    QString format = m_ui->timeEditStart->displayFormat()
-                     .replace( "ap",  "" )
-                     .replace( "AP",  "" )
+    QString format = originalDateTimeFormat
+                     .replace( "ap", "" )
+                     .replace( "AP", "" )
                      .simplified();
     m_ui->timeEditStart->setDisplayFormat( format );
     m_ui->timeEditEnd->setDisplayFormat( format );

--- a/Charm/EventEditor.ui
+++ b/Charm/EventEditor.ui
@@ -495,7 +495,11 @@
     </widget>
    </item>
    <item row="2" column="4">
-    <widget class="QTimeEdit" name="timeEditStart"/>
+    <widget class="QTimeEdit" name="timeEditStart">
+     <property name="displayFormat">
+      <string>h:mm AP</string>
+     </property>
+    </widget>
    </item>
    <item row="2" column="5">
     <widget class="QPushButton" name="startToNowButton">
@@ -528,7 +532,11 @@
     </widget>
    </item>
    <item row="3" column="4">
-    <widget class="QTimeEdit" name="timeEditEnd"/>
+    <widget class="QTimeEdit" name="timeEditEnd">
+     <property name="displayFormat">
+      <string>h:mm AP</string>
+     </property>
+    </widget>
    </item>
    <item row="3" column="5">
     <widget class="QPushButton" name="endToNowButton">


### PR DESCRIPTION
This only seems to appear in Linux on 4.8.0.

Fixes #32.
