### PR TITLE
 Compiling Charm in Debug mode no longer shortens idle detection timeout.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,11 +147,6 @@ ENDIF()
 
 IF( CMAKE_BUILD_TYPE MATCHES "^[Rr]elease$" )
     ADD_DEFINITIONS( -DQT_NO_DEBUG_OUTPUT )
-ELSE()
-    MESSAGE( WARNING
-        "Only run Charm in Debug mode if you are doing development!\n"
-        "Things like idle detection behave very differently in Debug mode."
-    )
 ENDIF()
 
 # Always include the source and build directories in the include path
@@ -190,6 +185,7 @@ SET( ICONS_DIR "${CMAKE_SOURCE_DIR}/Charm/Icons" )
 
 OPTION( CHARM_IDLE_DETECTION "Build the Charm idle detector" ON )
 OPTION( CHARM_TIMESHEET_TOOLS "Build the Charm timesheet tools" OFF )
+set( CHARM_IDLE_TIME "360" CACHE STRING "Set the idle timeout (default 360)" )
 
 ADD_SUBDIRECTORY( Core )
 ADD_SUBDIRECTORY( Charm )

--- a/Charm/Idle/IdleDetector.cpp
+++ b/Charm/Idle/IdleDetector.cpp
@@ -9,15 +9,9 @@
 #include "WindowsIdleDetector.h"
 #include "X11IdleDetector.h"
 
-#ifdef NDEBUG
-static const int IDLE_TIME = 360;
-#else
-static const int IDLE_TIME = 10;
-#endif
-
 IdleDetector::IdleDetector( QObject* parent )
     : QObject( parent )
-    , m_idlenessDuration( IDLE_TIME )
+    , m_idlenessDuration( CHARM_IDLE_TIME ) // from CharmCMake.h
 {
 }
 

--- a/CharmCMake.h.cmake
+++ b/CharmCMake.h.cmake
@@ -4,3 +4,5 @@
 #cmakedefine CHARM_IDLE_DETECTION
 /* Defined if idle detection is available on X11 */
 #cmakedefine CHARM_IDLE_DETECTION_AVAILABLE_X11 1
+/* Delay for idle detection, default is 360 */
+#define CHARM_IDLE_TIME @CHARM_IDLE_TIME@


### PR DESCRIPTION
This is now a separate setting in the CMakeCache.txt (or cmake command line)
for people who want to debug idle detection.
