### PR TITLE
Manually encode '+' character, even in Qt5

### DIFF
--- a/Charm/HttpClient/HttpJob.cpp
+++ b/Charm/HttpClient/HttpJob.cpp
@@ -234,7 +234,7 @@ bool HttpJob::execute(int state, QNetworkAccessManager *manager)
         QUrlQuery urlQuery;
         urlQuery.addQueryItem("j_username", m_username);
         urlQuery.addQueryItem("j_password", m_password);
-        QByteArray encodedQueryPlusPlus = urlQuery.query(QUrl::FullyEncoded).toUtf8();
+        QByteArray encodedQueryPlusPlus = urlQuery.query(QUrl::FullyEncoded).toUtf8().replace('+', "%2b");
 #endif
 
         QNetworkRequest request(m_loginUrl);


### PR DESCRIPTION
From qurlquery.cpp:
// The RFC says these are the delimiters:
//    gen-delims    = ":" / "/" / "?" / "#" / "[" / "]" / "@"
//    sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
//                  / "*" / "+" / "," / ";" / "="
// [...]
// The "+" sub-delimiter is always left untouched. We never encode "+" to "%2B"
// nor do we decode "%2B" to "+", no matter what the user asks.

No rational is given for this decision. No QUrlQuery::ActuallyReallyFullyEncodedThisTime. Just broken behavior.
