### PR TITLE
Add Ctrl+Return shortcut to the event editor dialog, triggers OK button.

### DIFF
--- a/Charm/EventEditor.cpp
+++ b/Charm/EventEditor.cpp
@@ -30,6 +30,9 @@ EventEditor::EventEditor( const Event& event, QWidget* parent )
     m_ui->dateEditEnd->calendarWidget()->setFirstDayOfWeek( Qt::Monday );
     m_ui->dateEditStart->calendarWidget()->setFirstDayOfWeek( Qt::Monday );
 
+    // Ctrl+Return for OK
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setShortcut(Qt::CTRL + Qt::Key_Return);
+
     // connect stuff:
     connect( m_ui->spinBoxHours, SIGNAL( valueChanged( int ) ),
              SLOT( durationHoursEdited( int ) ) );


### PR DESCRIPTION
I tried to get this into Qt itself, it was refused, so let's do it where
it makes sense (KF5 will do it on KDE workspaces automatically, but this
is also useful on other platforms for dialogs such as this one, with a textedit)
