### PR TITLE
Show week numbers in date pickers

### DIFF
--- a/Charm/EnterVacationDialog.cpp
+++ b/Charm/EnterVacationDialog.cpp
@@ -67,7 +67,9 @@ EnterVacationDialog::EnterVacationDialog( QWidget* parent )
 
     m_ui->setupUi( this );
     m_ui->startDate->calendarWidget()->setFirstDayOfWeek( Qt::Monday );
+    m_ui->startDate->calendarWidget()->setVerticalHeaderFormat( QCalendarWidget::ISOWeekNumbers );
     m_ui->endDate->calendarWidget()->setFirstDayOfWeek( Qt::Monday );
+    m_ui->endDate->calendarWidget()->setVerticalHeaderFormat( QCalendarWidget::ISOWeekNumbers );
     //set next week as default range
     const QDate referenceDate = QDate::currentDate().addDays( 7 );
     m_ui->startDate->setDate( Charm::weekDayInWeekOf( Qt::Monday, referenceDate ) );

--- a/Charm/EventEditor.cpp
+++ b/Charm/EventEditor.cpp
@@ -28,7 +28,9 @@ EventEditor::EventEditor( const Event& event, QWidget* parent )
     m_ui = new Ui::EventEditor();
     m_ui->setupUi( this );
     m_ui->dateEditEnd->calendarWidget()->setFirstDayOfWeek( Qt::Monday );
+    m_ui->dateEditEnd->calendarWidget()->setVerticalHeaderFormat( QCalendarWidget::ISOWeekNumbers );
     m_ui->dateEditStart->calendarWidget()->setFirstDayOfWeek( Qt::Monday );
+    m_ui->dateEditStart->calendarWidget()->setVerticalHeaderFormat( QCalendarWidget::ISOWeekNumbers );
 
     // Ctrl+Return for OK
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setShortcut(Qt::CTRL + Qt::Key_Return);

--- a/Charm/Reports/ActivityReport.cpp
+++ b/Charm/Reports/ActivityReport.cpp
@@ -34,7 +34,9 @@ ActivityReportConfigurationDialog::ActivityReportConfigurationDialog( QWidget* p
 
     m_ui->setupUi( this );
     m_ui->dateEditEnd->calendarWidget()->setFirstDayOfWeek( Qt::Monday );
+    m_ui->dateEditEnd->calendarWidget()->setVerticalHeaderFormat( QCalendarWidget::ISOWeekNumbers );
     m_ui->dateEditStart->calendarWidget()->setFirstDayOfWeek( Qt::Monday );
+    m_ui->dateEditStart->calendarWidget()->setVerticalHeaderFormat( QCalendarWidget::ISOWeekNumbers );
 
     connect( m_ui->buttonBox, SIGNAL(accepted()), this, SLOT(accept()) );
     connect( m_ui->buttonBox, SIGNAL(rejected()), this, SLOT(reject()) );

--- a/Charm/Reports/WeeklyTimesheet.cpp
+++ b/Charm/Reports/WeeklyTimesheet.cpp
@@ -92,6 +92,7 @@ WeeklyTimesheetConfigurationDialog::WeeklyTimesheetConfigurationDialog( QWidget*
 
     m_ui->setupUi( this );
     m_ui->dateEditDay->calendarWidget()->setFirstDayOfWeek( Qt::Monday );
+    m_ui->dateEditDay->calendarWidget()->setVerticalHeaderFormat( QCalendarWidget::ISOWeekNumbers );
     connect( m_ui->buttonBox, SIGNAL(accepted()), this, SLOT(accept()) );
     connect( m_ui->buttonBox, SIGNAL(rejected()), this, SLOT(reject()) );
 

--- a/Charm/TaskEditor.cpp
+++ b/Charm/TaskEditor.cpp
@@ -24,7 +24,9 @@ TaskEditor::TaskEditor( QWidget* parent )
 {
     m_ui->setupUi( this );
     m_ui->dateEditFrom->calendarWidget()->setFirstDayOfWeek( Qt::Monday );
+    m_ui->dateEditFrom->calendarWidget()->setVerticalHeaderFormat( QCalendarWidget::ISOWeekNumbers );
     m_ui->dateEditTo->calendarWidget()->setFirstDayOfWeek( Qt::Monday );
+    m_ui->dateEditTo->calendarWidget()->setVerticalHeaderFormat( QCalendarWidget::ISOWeekNumbers );
     connect( m_ui->pushButtonParent, SIGNAL( clicked() ),
              SLOT( slotSelectParent() ) );
     connect( m_ui->dateEditFrom, SIGNAL( dateChanged( QDate ) ),


### PR DESCRIPTION
That actually makes sense for every occurence of QDateEdit. Especially
when manually creating events inside the event editor window this is really helpful.

Note that this is disabled by default in QDateEdit (see usage of
QCalendarWidget::setVerticalHeaderFormat inside QCalendarPopup::verifyCalendarInstance()
inside qdatetimeedit.cpp). Not sure why, probably because the majority of users of
QDateEdit don't need that feature(?).
