### PR TITLE
Qt5: Fix Task delegate painting

### DIFF
--- a/Charm/TasksViewDelegate.cpp
+++ b/Charm/TasksViewDelegate.cpp
@@ -127,18 +127,17 @@ bool TasksViewDelegate::editorEvent(QEvent *event, QAbstractItemModel *model,
 QRect TasksViewDelegate::checkBoxRect( const QStyleOptionViewItem &option,
                                        const QVariant &variant ) const
 {
-#if QT_VERSION < 0x050000
     const QRect bounding = option.rect; // TODO adjust if recording
 
-    QRect cbRect = check(option, bounding, variant);
+#if QT_VERSION < QT_VERSION_CHECK(5,0,0)
+    const QRect cbRect = check(option, bounding, variant);
+#else
+    const QRect cbRect = doCheck(option, bounding, variant);
+#endif
 
     // Position checkbox on the right, and vertically aligned
     return QStyle::alignedRect(option.direction, Qt::AlignRight | Qt::AlignVCenter,
                                cbRect.size(), bounding);
-#else
-    //TODO probably more needed for Qt5, needs testing
-    return option.rect;
-#endif
 }
 
 void TasksViewDelegate::updateEditorGeometry( QWidget * editor,


### PR DESCRIPTION
Remove TODO: check() is doCheck() now, that's it.
