### PR TITLE
Make attempts to use QMake fail on !android

### DIFF
--- a/Charm.pro
+++ b/Charm.pro
@@ -1,3 +1,4 @@
+!android: error("Building Charm with QMake is not supported, and used only for Qt/Android experiments. For everything else, please use the CMake build system.")
 
 QT += core gui xml sql network widgets
 INCLUDEPATH += Core/


### PR DESCRIPTION
On anything but Android, QMake isn't supported (and even there
it's not maintained). So print useful an useful error pointing to
CMake.

Fixes Issue #147 (see also Issue #146)
