### PR TITLE
Correction of two problems in the task view

### DIFF
--- a/Charm/TasksView.cpp
+++ b/Charm/TasksView.cpp
@@ -255,6 +255,7 @@ void TasksView::configureUi()
          const QItemSelectionModel* smodel =  m_treeView->selectionModel();
          connect( smodel, SIGNAL( currentChanged( const QModelIndex&, const QModelIndex& ) ), SLOT( configureUi() ) );
          connect( smodel, SIGNAL( selectionChanged( const QItemSelection&, const QItemSelection& ) ), SLOT( configureUi() ) );
+         connect( smodel, SIGNAL( currentColumnChanged( QModelIndex, QModelIndex ) ), SLOT( configureUi() ) );
          connect( filter, SIGNAL( eventActivationNotice( EventId ) ),
                   SLOT( slotEventActivated( EventId ) ) );
          connect( filter, SIGNAL( eventDeactivationNotice( EventId ) ),


### PR DESCRIPTION
- When we delete the last subtask, the selection move to parent task but delete action is not enabled
- When we add subtask, the selection stay in parent task and the delete action is still enabled
