### PR TITLE
Fix a crash when updating activity report.

### DIFF
--- a/Charm/Widgets/ReportPreviewWindow.cpp
+++ b/Charm/Widgets/ReportPreviewWindow.cpp
@@ -41,7 +41,8 @@ void ReportPreviewWindow::setDocument( const QTextDocument* document )
 {
     if ( document != 0 ) {
         // we keep a copy, to be able to show different versions of the same document
-        m_document.reset( document->clone() );
+        QScopedPointer<QTextDocument> docClone( document->clone() );
+        m_document.swap( docClone );
         m_ui->textBrowser->setDocument( m_document.data() );
     } else {
         m_ui->textBrowser->setDocument( 0 );


### PR DESCRIPTION
We need to keep old document alive when setting a new one, because
QTextView wants to disconnect itself from some old document's signals.
