### PR TITLE
Handle http basic auth

### DIFF
--- a/Charm/HttpClient/HttpJob.h
+++ b/Charm/HttpClient/HttpJob.h
@@ -10,6 +10,8 @@ namespace QKeychain {
 
 class QNetworkAccessManager;
 class QNetworkReply;
+class QNetworkRequest;
+class QAuthenticator;
 
 class HttpJob : public QObject
 {
@@ -90,6 +92,7 @@ private Q_SLOTS:
     void next();
     void passwordRead(QKeychain::Job*);
     void passwordWritten();
+    void authenticationRequired(QNetworkReply *reply , QAuthenticator *authenticator);
 
 private:
     QNetworkAccessManager *m_networkManager;
@@ -101,6 +104,7 @@ private:
     QUrl m_loginUrl;
     QUrl m_portalUrl;
     bool m_lastAuthenticationFailed;
+    bool m_authenticationDoneAlready;
     bool m_passwordReadError;
 };
 


### PR DESCRIPTION
This makes use of QNM's authenticationRequired signal to hook
into http basic auth requests and pass on name+password.

Notes
1. the signal will not be emitted in case form-based logins
are used because no auth-required is send back to the client.
2. this is kind of a migration-strategy to keep the previous
way working as-is but in case we get a auth-required, like
happens with http basic auth enabled, we use that one the
and skip form login.
3. this way its possible to switch at the server-side the
auth method and keep the client transparent working.
4. price payed is an additional roundtrip, in case http
basic auth is enabled, which wouldn't be needed because
the credentials could also be embedded direct into the
request. Anyhow, this solution is the most less offensive
way to support both, form-login and http basic auth, for
the time being.