### PR TITLE
Do not hardcode colors in the report stylesheet.

### DIFF
--- a/Charm/ViewHelpers.cpp
+++ b/Charm/ViewHelpers.cpp
@@ -24,6 +24,7 @@
 #include "ViewHelpers.h"
 
 #include <QtAlgorithms>
+#include <QFile>
 
 void Charm::connectControllerAndView( Controller* controller, CharmWindow* view )
 {
@@ -81,4 +82,23 @@ QString Charm::elidedTaskName( const QString& text, const QFont& font, int width
     }
 
     return metrics.elidedText( text, Qt::ElideMiddle, width );
+}
+
+QString Charm::reportStylesheet( const QPalette& palette )
+{
+    QString style;
+    QFile stylesheet( ":/Charm/report_stylesheet.sty" );
+    if ( stylesheet.open( QIODevice::ReadOnly | QIODevice::Text ) ) {
+        style = stylesheet.readAll();
+        style.replace(QLatin1String("@header_row_background_color@"), palette.highlight().color().name());
+        style.replace(QLatin1String("@header_row_foreground_color@"), palette.highlightedText().color().name());
+        style.replace(QLatin1String("@alternate_row_background_color@"), palette.alternateBase().color().name());
+        style.replace(QLatin1String("@event_attributes_row_background_color@"), palette.midlight().color().name());
+        if ( style.isEmpty() ) {
+            qDebug() << "reportStylesheet: default style sheet is empty, too bad";
+        }
+    } else {
+        qDebug() << "reportStylesheet: cannot load report style sheet:" << stylesheet.errorString();
+    }
+    return style;
 }

--- a/Charm/ViewHelpers.h
+++ b/Charm/ViewHelpers.h
@@ -42,6 +42,7 @@ namespace Charm {
      * under the parent task, which includes the parent task. */
     EventIdList filteredBySubtree( EventIdList, TaskId parent, bool exclude=false );
     QString elidedTaskName( const QString& text, const QFont& font, int width );
+    QString reportStylesheet( const QPalette& palette );
 }
 
 #endif

--- a/Charm/Widgets/ActivityReport.cpp
+++ b/Charm/Widgets/ActivityReport.cpp
@@ -400,17 +400,7 @@ void ActivityReport::slotUpdate()
 
     // NOTE: seems like the style sheet has to be set before the html
     // code is pushed into the QTextDocument
-    QFile stylesheet( ":/Charm/report_stylesheet.sty" );
-    if ( stylesheet.open( QIODevice::ReadOnly | QIODevice::Text ) ) {
-        QString style = stylesheet.readAll();
-        if ( !style.isEmpty() ) {
-            report->setDefaultStyleSheet( style );
-        } else {
-            qDebug() << "WeeklyTimeSheet::create: default style sheet is empty, too bad";
-        }
-    } else {
-        qDebug() << "WeeklyTimeSheet::create: cannot load report style sheet: " << stylesheet.errorString();
-    }
+    report->setDefaultStyleSheet(Charm::reportStylesheet(palette()));
 
     report->setHtml( doc.toString() );
     setDocument( report );

--- a/Charm/Widgets/MonthlyTimesheet.cpp
+++ b/Charm/Widgets/MonthlyTimesheet.cpp
@@ -299,17 +299,7 @@ void MonthlyTimeSheetReport::update()
 
     // NOTE: seems like the style sheet has to be set before the html
     // code is pushed into the QTextDocument
-    QFile stylesheet( ":/Charm/report_stylesheet.sty" );
-    if ( stylesheet.open( QIODevice::ReadOnly | QIODevice::Text ) ) {
-        QString style = stylesheet.readAll();
-        if ( !style.isEmpty() ) {
-            report.setDefaultStyleSheet( style );
-        } else {
-            qDebug() << "MonthlyTimeSheet::create: default style sheet is empty, too bad";
-        }
-    } else {
-        qDebug() << "MonthlyTimeSheet::create: cannot load report style sheet: " << stylesheet.errorString();
-    }
+    report.setDefaultStyleSheet(Charm::reportStylesheet(palette()));
 
     report.setHtml( doc.toString() );
     setDocument( &report );

--- a/Charm/Widgets/WeeklyTimesheet.cpp
+++ b/Charm/Widgets/WeeklyTimesheet.cpp
@@ -25,7 +25,6 @@
 #include "Reports/WeeklyTimesheetXmlWriter.h"
 
 #include <QCalendarWidget>
-#include <QFile>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QSettings>
@@ -507,17 +506,7 @@ void WeeklyTimeSheetReport::update()
 
     // NOTE: seems like the style sheet has to be set before the html
     // code is pushed into the QTextDocument
-    QFile stylesheet( ":/Charm/report_stylesheet.sty" );
-    if ( stylesheet.open( QIODevice::ReadOnly | QIODevice::Text ) ) {
-        QString style = stylesheet.readAll();
-        if ( !style.isEmpty() ) {
-            report.setDefaultStyleSheet( style );
-        } else {
-            qDebug() << "WeeklyTimeSheet::create: default style sheet is empty, too bad";
-        }
-    } else {
-        qDebug() << "WeeklyTimeSheet::create: cannot load report style sheet:" << stylesheet.errorString();
-    }
+    report.setDefaultStyleSheet(Charm::reportStylesheet(palette()));
 
     report.setHtml( doc.toString() );
     setDocument( &report );

--- a/Charm/Widgets/report_stylesheet.sty
+++ b/Charm/Widgets/report_stylesheet.sty
@@ -23,12 +23,12 @@ td {
 }
 
 .header_row {
-  background-color: #BBBBBB;
-  color: #181818;
+  background-color: @header_row_background_color@;
+  color: @header_row_foreground_color@;
 }
 
 .alternate_row {
-  background-color: #EEEEEE;
+  background-color: @alternate_row_background_color@;
 }
 
 .event_description {
@@ -42,5 +42,5 @@ td {
 }
 
 .event_attributes_row {
-  background-color: #DDDDDD;
+  background-color: @event_attributes_row_background_color@;
 }


### PR DESCRIPTION
Instead, we add variables to the style sheet and replace it with
color names taken from the current widget palette.

I tested it on both a bright and a dark color scheme, it now always
looks nice.

This addresses https://github.com/KDAB/Charm/issues/201