### PR TITLE
clang-tidy: Use override where possible

### DIFF
--- a/Charm/ApplicationCore.h
+++ b/Charm/ApplicationCore.h
@@ -64,7 +64,7 @@ public:
         ShowAndRaise
     };
     explicit ApplicationCore( TaskId startupTask, QObject* parent = nullptr );
-    ~ApplicationCore();
+    ~ApplicationCore() override;
 
     static ApplicationCore& instance();
     static bool hasInstance();

--- a/Charm/Commands/CommandAddTask.h
+++ b/Charm/Commands/CommandAddTask.h
@@ -34,7 +34,7 @@ class CommandAddTask : public CharmCommand
 
 public:
     explicit CommandAddTask( const Task&, QObject* parent = nullptr );
-    ~CommandAddTask();
+    ~CommandAddTask() override;
 
     bool prepare() override;
     bool execute( ControllerInterface* ) override;

--- a/Charm/Commands/CommandDeleteEvent.h
+++ b/Charm/Commands/CommandDeleteEvent.h
@@ -34,7 +34,7 @@ class CommandDeleteEvent : public CharmCommand
 
 public:
     explicit CommandDeleteEvent( const Event&, QObject* parent = nullptr );
-    ~CommandDeleteEvent();
+    ~CommandDeleteEvent() override;
 
     bool prepare() override;
     bool execute( ControllerInterface* ) override;

--- a/Charm/Commands/CommandDeleteTask.h
+++ b/Charm/Commands/CommandDeleteTask.h
@@ -34,7 +34,7 @@ class CommandDeleteTask : public CharmCommand
 
 public:
     explicit CommandDeleteTask( const Task&, QObject* parent = nullptr );
-    ~CommandDeleteTask();
+    ~CommandDeleteTask() override;
 
     bool prepare() override;
     bool execute( ControllerInterface* ) override;

--- a/Charm/Commands/CommandExportToXml.h
+++ b/Charm/Commands/CommandExportToXml.h
@@ -33,7 +33,7 @@ class CommandExportToXml : public CharmCommand
     Q_OBJECT
 public:
     explicit CommandExportToXml( QString filename, QObject* parent );
-    ~CommandExportToXml();
+    ~CommandExportToXml() override;
 
     bool prepare() override;
     bool execute( ControllerInterface* ) override;

--- a/Charm/Commands/CommandImportFromXml.h
+++ b/Charm/Commands/CommandImportFromXml.h
@@ -33,7 +33,7 @@ class CommandImportFromXml : public CharmCommand
     Q_OBJECT
 public:
     explicit CommandImportFromXml( QString filename, QObject* parent );
-    ~CommandImportFromXml();
+    ~CommandImportFromXml() override;
 
     bool prepare() override;
     bool execute( ControllerInterface* ) override;

--- a/Charm/Commands/CommandMakeAndActivateEvent.h
+++ b/Charm/Commands/CommandMakeAndActivateEvent.h
@@ -36,7 +36,7 @@ class CommandMakeAndActivateEvent : public CharmCommand
 
 public:
     explicit CommandMakeAndActivateEvent( const Task&, QObject* parent );
-    ~CommandMakeAndActivateEvent();
+    ~CommandMakeAndActivateEvent() override;
 
     bool prepare() override;
     bool execute( ControllerInterface* ) override;

--- a/Charm/Commands/CommandMakeEvent.h
+++ b/Charm/Commands/CommandMakeEvent.h
@@ -37,7 +37,7 @@ class CommandMakeEvent : public CharmCommand
 public:
     explicit CommandMakeEvent( const Task& task, QObject* parent );
     explicit CommandMakeEvent( const Event& event, QObject* parent );
-    ~CommandMakeEvent();
+    ~CommandMakeEvent() override;
 
     bool prepare() override;
     bool execute( ControllerInterface* ) override;

--- a/Charm/Commands/CommandModifyEvent.h
+++ b/Charm/Commands/CommandModifyEvent.h
@@ -34,7 +34,7 @@ class CommandModifyEvent : public CharmCommand
 
 public:
     explicit CommandModifyEvent( const Event&, const Event&, QObject* parent = nullptr );
-    ~CommandModifyEvent();
+    ~CommandModifyEvent() override;
 
     bool prepare() override;
     bool execute( ControllerInterface* ) override;

--- a/Charm/Commands/CommandModifyTask.h
+++ b/Charm/Commands/CommandModifyTask.h
@@ -34,7 +34,7 @@ class CommandModifyTask : public CharmCommand
 
 public:
     explicit CommandModifyTask( const Task&, QObject* parent = nullptr );
-    ~CommandModifyTask();
+    ~CommandModifyTask() override;
 
     bool prepare() override;
     bool execute( ControllerInterface* ) override;

--- a/Charm/Commands/CommandRelayCommand.h
+++ b/Charm/Commands/CommandRelayCommand.h
@@ -37,7 +37,7 @@ class CommandRelayCommand : public CharmCommand
 
 public:
     explicit CommandRelayCommand( QObject* parent );
-    ~CommandRelayCommand();
+    ~CommandRelayCommand() override;
 
     void setCommand( CharmCommand* command );
 

--- a/Charm/Commands/CommandSetAllTasks.h
+++ b/Charm/Commands/CommandSetAllTasks.h
@@ -33,7 +33,7 @@ class CommandSetAllTasks : public CharmCommand
 
 public:
     explicit CommandSetAllTasks( const TaskList&, QObject* parent );
-    ~CommandSetAllTasks();
+    ~CommandSetAllTasks() override;
 
     bool prepare() override;
     bool execute( ControllerInterface* ) override;

--- a/Charm/EventModelAdapter.h
+++ b/Charm/EventModelAdapter.h
@@ -44,7 +44,7 @@ class EventModelAdapter : public QAbstractListModel,
 
 public:
     explicit EventModelAdapter( CharmDataModel* parent );
-    virtual ~EventModelAdapter();
+    ~EventModelAdapter() override;
 
     int rowCount( const QModelIndex& parent = QModelIndex() ) const override;
 

--- a/Charm/EventModelFilter.h
+++ b/Charm/EventModelFilter.h
@@ -43,7 +43,7 @@ class EventModelFilter : public QSortFilterProxyModel,
 
 public:
     explicit EventModelFilter( CharmDataModel*, QObject* parent = nullptr );
-    virtual ~EventModelFilter();
+    ~EventModelFilter() override;
 
     /** Returns the total number of seconds of all events in the model. */
     int totalDuration() const;

--- a/Charm/HttpClient/CheckForUpdatesJob.h
+++ b/Charm/HttpClient/CheckForUpdatesJob.h
@@ -50,7 +50,7 @@ public:
     };
 
     explicit CheckForUpdatesJob( QObject* parent=nullptr );
-    ~CheckForUpdatesJob();
+    ~CheckForUpdatesJob() override;
 
     void start();
     void setUrl( const QUrl& url );

--- a/Charm/HttpClient/GetProjectCodesJob.h
+++ b/Charm/HttpClient/GetProjectCodesJob.h
@@ -34,7 +34,7 @@ class GetProjectCodesJob : public HttpJob
 public:
 
     explicit GetProjectCodesJob(QObject* parent=nullptr);
-    ~GetProjectCodesJob();
+    ~GetProjectCodesJob() override;
 
     QByteArray payload() const;
 

--- a/Charm/HttpClient/GetUserInfoJob.h
+++ b/Charm/HttpClient/GetUserInfoJob.h
@@ -35,7 +35,7 @@ class GetUserInfoJob : public HttpJob
 public:
 
     explicit GetUserInfoJob(QObject* parent=nullptr, const QString &schema = " ");
-    ~GetUserInfoJob();
+    ~GetUserInfoJob() override;
 
     QByteArray userInfo() const;
 

--- a/Charm/HttpClient/HttpJob.h
+++ b/Charm/HttpClient/HttpJob.h
@@ -54,7 +54,7 @@ public:
     };
 
     explicit HttpJob(QObject* parent=nullptr);
-    ~HttpJob();
+    ~HttpJob() override;
 
     QString username() const;
     void setUsername(const QString &value);

--- a/Charm/HttpClient/UploadTimesheetJob.h
+++ b/Charm/HttpClient/UploadTimesheetJob.h
@@ -34,7 +34,7 @@ class UploadTimesheetJob : public HttpJob
 public:
 
     explicit UploadTimesheetJob(QObject* parent=nullptr);
-    ~UploadTimesheetJob();
+    ~UploadTimesheetJob() override;
 
     QByteArray payload() const;
     void setPayload(const QByteArray &payload);

--- a/Charm/TaskModelAdapter.h
+++ b/Charm/TaskModelAdapter.h
@@ -63,7 +63,7 @@ class TaskModelAdapter :  public QAbstractItemModel,
 
 public:
     explicit TaskModelAdapter( CharmDataModel* parent );
-    ~TaskModelAdapter();
+    ~TaskModelAdapter() override;
 
     // reimplement QAbstractItemModel:
     int columnCount( const QModelIndex& parent = QModelIndex() ) const override;

--- a/Charm/ViewFilter.h
+++ b/Charm/ViewFilter.h
@@ -45,7 +45,7 @@ class ViewFilter : public QSortFilterProxyModel,
     Q_OBJECT
 public:
     explicit ViewFilter( CharmDataModel*, QObject* parent = nullptr );
-    virtual ~ViewFilter();
+    ~ViewFilter() override;
 
     // implement TaskModelInterface
     Task taskForIndex( const QModelIndex& ) const override;

--- a/Charm/Widgets/ActivityReport.h
+++ b/Charm/Widgets/ActivityReport.h
@@ -44,7 +44,7 @@ class ActivityReportConfigurationDialog : public ReportConfigurationDialog
 
 public:
     explicit ActivityReportConfigurationDialog( QWidget* parent );
-    ~ActivityReportConfigurationDialog();
+    ~ActivityReportConfigurationDialog() override;
 
     void showReportPreviewDialog() override;
 
@@ -75,7 +75,7 @@ class ActivityReport : public ReportPreviewWindow
 
 public:
     explicit ActivityReport( QWidget* parent = nullptr );
-    ~ActivityReport();
+    ~ActivityReport() override;
 
     void setReportProperties(const QDate& start, const QDate& end,
         QSet<TaskId> rootTasks, QSet<TaskId> rootExcludeTasks );

--- a/Charm/Widgets/CharmAboutDialog.h
+++ b/Charm/Widgets/CharmAboutDialog.h
@@ -37,7 +37,7 @@ class CharmAboutDialog : public QDialog
 
 public:
     explicit CharmAboutDialog( QWidget* parent = nullptr );
-    ~CharmAboutDialog();
+    ~CharmAboutDialog() override;
 
 private:
     QScopedPointer<Ui::CharmAboutDialog> m_ui;

--- a/Charm/Widgets/CharmNewReleaseDialog.h
+++ b/Charm/Widgets/CharmNewReleaseDialog.h
@@ -38,7 +38,7 @@ class CharmNewReleaseDialog : public QDialog
 
 public:
     explicit CharmNewReleaseDialog( QWidget* parent = nullptr );
-    ~CharmNewReleaseDialog();
+    ~CharmNewReleaseDialog() override;
 
     void setVersion( const QString& newVersion , const QString& localVersion );
     void setDownloadLink( const QUrl& link );

--- a/Charm/Widgets/CharmPreferences.h
+++ b/Charm/Widgets/CharmPreferences.h
@@ -36,7 +36,7 @@ class CharmPreferences : public QDialog
 public:
     explicit CharmPreferences( const Configuration& config,
                                QWidget* parent = nullptr );
-    ~CharmPreferences();
+    ~CharmPreferences() override;
 
     Configuration::DurationFormat durationFormat() const;
     bool detectIdling() const;

--- a/Charm/Widgets/CharmWindow.h
+++ b/Charm/Widgets/CharmWindow.h
@@ -70,8 +70,8 @@ public:
     void hideEvent( QHideEvent* ) override;
     void keyPressEvent( QKeyEvent* event ) override;
 
-    virtual void saveGuiState() override;
-    virtual void restoreGuiState() override;
+    void saveGuiState() override;
+    void restoreGuiState() override;
 
     static void showView( QWidget* w );
     static bool showHideView( QWidget* w );

--- a/Charm/Widgets/CommentEditorPopup.h
+++ b/Charm/Widgets/CommentEditorPopup.h
@@ -38,7 +38,7 @@ class CommentEditorPopup : public QDialog
 
 public:
     explicit CommentEditorPopup( QWidget *parent = nullptr );
-    ~CommentEditorPopup();
+    ~CommentEditorPopup() override;
 
 public Q_SLOTS:
     void loadEvent( EventId id );

--- a/Charm/Widgets/EnterVacationDialog.h
+++ b/Charm/Widgets/EnterVacationDialog.h
@@ -39,7 +39,7 @@ class EnterVacationDialog : public QDialog {
     Q_OBJECT
 public:
     explicit EnterVacationDialog( QWidget* parent=nullptr );
-    ~EnterVacationDialog();
+    ~EnterVacationDialog() override;
 
     EventList events() const;
 

--- a/Charm/Widgets/EventEditor.h
+++ b/Charm/Widgets/EventEditor.h
@@ -40,7 +40,7 @@ class EventEditor: public QDialog
 
 public:
     explicit EventEditor( const Event& event, QWidget* parent = nullptr );
-    virtual ~EventEditor();
+    ~EventEditor() override;
 
     // return the result after the dialog has been accepted
     Event eventResult() const;

--- a/Charm/Widgets/EventView.h
+++ b/Charm/Widgets/EventView.h
@@ -53,7 +53,7 @@ class EventView : public QDialog,
 
 public:
     explicit EventView( QWidget* parent = nullptr );
-    ~EventView();
+    ~EventView() override;
 
     void makeVisibleAndCurrent( const Event& );
 

--- a/Charm/Widgets/FindAndReplaceEventsDialog.h
+++ b/Charm/Widgets/FindAndReplaceEventsDialog.h
@@ -45,7 +45,7 @@ class FindAndReplaceEventsDialog : public QDialog
 
 public:
     explicit FindAndReplaceEventsDialog( QWidget* parent = nullptr );
-    ~FindAndReplaceEventsDialog();
+    ~FindAndReplaceEventsDialog() override;
 
     QList<Event> modifiedEvents() const;
 

--- a/Charm/Widgets/IdleCorrectionDialog.h
+++ b/Charm/Widgets/IdleCorrectionDialog.h
@@ -43,7 +43,7 @@ public:
     };
 
     explicit IdleCorrectionDialog( QWidget* parent = nullptr );
-    ~IdleCorrectionDialog();
+    ~IdleCorrectionDialog() override;
 
     Result result() const;
 

--- a/Charm/Widgets/MonthlyTimesheet.h
+++ b/Charm/Widgets/MonthlyTimesheet.h
@@ -36,7 +36,7 @@ class MonthlyTimeSheetReport : public TimeSheetReport
 
 public:
     explicit MonthlyTimeSheetReport( QWidget* parent = nullptr );
-    virtual ~MonthlyTimeSheetReport();
+    ~MonthlyTimeSheetReport() override;
 
     void setReportProperties( const QDate& start,
                               const QDate& end,

--- a/Charm/Widgets/MonthlyTimesheetConfigurationDialog.h
+++ b/Charm/Widgets/MonthlyTimesheetConfigurationDialog.h
@@ -39,7 +39,7 @@ class MonthlyTimesheetConfigurationDialog : public ReportConfigurationDialog
 
 public:
     explicit MonthlyTimesheetConfigurationDialog( QWidget* parent );
-    virtual ~MonthlyTimesheetConfigurationDialog();
+    ~MonthlyTimesheetConfigurationDialog() override;
 
     void showReportPreviewDialog() override;
     void showEvent( QShowEvent* ) override;

--- a/Charm/Widgets/NotificationPopup.h
+++ b/Charm/Widgets/NotificationPopup.h
@@ -37,7 +37,7 @@ class NotificationPopup : public QDialog
 
 public:
     explicit NotificationPopup( QWidget *parent = nullptr );
-    ~NotificationPopup();
+    ~NotificationPopup() override;
 
     void showNotification( const QString& title, const QString& message );
 

--- a/Charm/Widgets/ReportPreviewWindow.h
+++ b/Charm/Widgets/ReportPreviewWindow.h
@@ -42,7 +42,7 @@ class ReportPreviewWindow : public QDialog
 
 public:
     explicit ReportPreviewWindow( QWidget* parent = nullptr );
-    virtual ~ReportPreviewWindow();
+    ~ReportPreviewWindow() override;
 
 signals:
     void anchorClicked(const QUrl& which);

--- a/Charm/Widgets/SelectTaskDialog.h
+++ b/Charm/Widgets/SelectTaskDialog.h
@@ -57,7 +57,7 @@ class SelectTaskDialog : public QDialog
 
 public:
     explicit SelectTaskDialog( QWidget* parent=nullptr );
-    ~SelectTaskDialog();
+    ~SelectTaskDialog() override;
 
     TaskId selectedTask() const;
     void setNonTrackableSelectable();

--- a/Charm/Widgets/TaskEditor.h
+++ b/Charm/Widgets/TaskEditor.h
@@ -41,7 +41,7 @@ class TaskEditor: public QDialog
 
 public:
     explicit TaskEditor( QWidget* parent = nullptr );
-    virtual ~TaskEditor();
+    ~TaskEditor() override;
 
     void setTask( const Task& task );
 

--- a/Charm/Widgets/TaskIdDialog.h
+++ b/Charm/Widgets/TaskIdDialog.h
@@ -39,7 +39,7 @@ class TaskIdDialog : public QDialog
 
 public:
     explicit TaskIdDialog( TaskModelInterface* model, TasksView* parent );
-    ~TaskIdDialog();
+    ~TaskIdDialog() override;
 
     void setSuggestedId( int );
     int selectedId() const;

--- a/Charm/Widgets/TasksView.h
+++ b/Charm/Widgets/TasksView.h
@@ -47,7 +47,7 @@ class TasksView : public QDialog,
 
 public:
     explicit TasksView (QWidget* parent = nullptr );
-    ~TasksView();
+    ~TasksView() override;
 
     void populateEditMenu( QMenu* );
 
@@ -65,8 +65,8 @@ public Q_SLOTS:
 signals:
     // FIXME connect to MainWindow
     void saveConfiguration();
-    void emitCommand( CharmCommand* );
-    void emitCommandRollback( CharmCommand* );
+    void emitCommand( CharmCommand* ) override;
+    void emitCommandRollback( CharmCommand* ) override;
 
 private slots:
     void actionNewTask();

--- a/Charm/Widgets/TimeTrackingWindow.h
+++ b/Charm/Widgets/TimeTrackingWindow.h
@@ -51,7 +51,7 @@ class TimeTrackingWindow : public CharmWindow,
     Q_OBJECT
 public:
     explicit TimeTrackingWindow( QWidget* parent = nullptr );
-    ~TimeTrackingWindow();
+    ~TimeTrackingWindow() override;
 
     enum VerboseMode {
         Verbose = 0,

--- a/Charm/Widgets/Timesheet.h
+++ b/Charm/Widgets/Timesheet.h
@@ -35,7 +35,7 @@ class TimeSheetReport : public ReportPreviewWindow
 
 public:
     explicit TimeSheetReport( QWidget* parent = nullptr );
-    virtual ~TimeSheetReport();
+    ~TimeSheetReport() override;
 
     virtual void setReportProperties( const QDate& start,
                                       const QDate& end,

--- a/Charm/Widgets/TrayIcon.h
+++ b/Charm/Widgets/TrayIcon.h
@@ -32,7 +32,7 @@ class TrayIcon : public QSystemTrayIcon
 
 public:
     explicit TrayIcon(QObject* parent = nullptr);
-    virtual ~TrayIcon();
+    ~TrayIcon() override;
 
 private Q_SLOTS:
     void slotActivated(QSystemTrayIcon::ActivationReason);

--- a/Charm/Widgets/WeeklyTimesheet.h
+++ b/Charm/Widgets/WeeklyTimesheet.h
@@ -51,7 +51,7 @@ class WeeklyTimesheetConfigurationDialog : public ReportConfigurationDialog
 
 public:
     explicit WeeklyTimesheetConfigurationDialog( QWidget* parent );
-    ~WeeklyTimesheetConfigurationDialog();
+    ~WeeklyTimesheetConfigurationDialog() override;
 
     void showReportPreviewDialog() override;
     void showEvent( QShowEvent* ) override;
@@ -78,7 +78,7 @@ class WeeklyTimeSheetReport : public TimeSheetReport
 
 public:
     explicit WeeklyTimeSheetReport( QWidget* parent = nullptr );
-    virtual ~WeeklyTimeSheetReport();
+    ~WeeklyTimeSheetReport() override;
 
     void setReportProperties( const QDate& start,
                               const QDate& end,

--- a/Core/CharmCommand.h
+++ b/Core/CharmCommand.h
@@ -63,7 +63,7 @@ class CharmCommand : public QObject
 
 public:
     explicit CharmCommand( const QString& description, QObject* parent = nullptr );
-    virtual ~CharmCommand();
+    ~CharmCommand() override;
 
     QString description() const;
 

--- a/Core/CharmDataModel.h
+++ b/Core/CharmDataModel.h
@@ -55,7 +55,7 @@ class CharmDataModel : public QObject
 
 public:
     CharmDataModel();
-    ~CharmDataModel();
+    ~CharmDataModel() override;
 
     void stateChanged( State previous, State next );
     /** Register a CharmDataModelAdapterInterface. */

--- a/Core/Controller.h
+++ b/Core/Controller.h
@@ -41,7 +41,7 @@ class Controller : public QObject,
 
 public:
     explicit Controller( QObject* parent = nullptr );
-    ~Controller();
+    ~Controller() override;
 
     void stateChanged( State previous, State next ) override;
     void persistMetaData( Configuration& ) override;

--- a/Tests/SqLiteStorageTests.h
+++ b/Tests/SqLiteStorageTests.h
@@ -34,7 +34,7 @@ class SqLiteStorageTests : public QObject
     Q_OBJECT
 public:
     SqLiteStorageTests();
-    ~SqLiteStorageTests();
+    ~SqLiteStorageTests() override;
 
 private:
     StorageInterface* m_storage;


### PR DESCRIPTION
Fixes a series of Clang warnings.

Note: 'override' on destructors breaks compat with MSVC2010, thus I'm
putting this up for review. You decide whether it's worth it.