### PR TITLE
Optimize usage of QDateTime and prevent UTC timezone where possible.

### DIFF
--- a/Charm/EventModelFilter.cpp
+++ b/Charm/EventModelFilter.cpp
@@ -52,7 +52,8 @@ bool EventModelFilter::lessThan( const QModelIndex& left, const QModelIndex& rig
     if ( left.column() == 0 && right.column() == 0 ) {
         const Event& leftEvent = m_model.eventForIndex( left );
         const Event& rightEvent = m_model.eventForIndex( right );
-        return leftEvent.startDateTime() < rightEvent.startDateTime();
+        // date comparison in UTC is much faster and just as correct
+        return leftEvent.startDateTime(Qt::UTC) < rightEvent.startDateTime(Qt::UTC);
     } else {
         return QSortFilterProxyModel::lessThan( left, right );
     }

--- a/Core/CharmDataModel.cpp
+++ b/Core/CharmDataModel.cpp
@@ -626,12 +626,16 @@ int CharmDataModel::activeEventCount() const
 EventIdList CharmDataModel::eventsThatStartInTimeFrame( const QDate& start,
                                                         const QDate& end ) const
 {
+    // do the comparisons in UTC, which is much faster as we only need to convert
+    // start and end date then
+    const QDateTime startUTC = QDateTime(start, QTime(0, 0, 0)).toUTC();
+    const QDateTime endUTC = QDateTime(end, QTime(0, 0, 0)).toUTC();
     EventIdList events;
     EventMap::const_iterator it;
     for ( it = m_events.begin();
           it != m_events.end(); ++it ) {
         const Event& event( it->second );
-        if ( event.startDateTime().date() >= start && event.startDateTime().date() < end ) {
+        if ( event.startDateTime(Qt::UTC) >= startUTC && event.startDateTime(Qt::UTC) < endUTC ) {
             events << event.id();
         }
     }
@@ -717,7 +721,8 @@ TaskIdList CharmDataModel::mostRecentlyUsedTasks() const
     for( EventMap::const_iterator it = events.begin(); it != events.end(); ++it ) {
         const TaskId id = it->second.taskId();
         // process use date
-        const QDateTime date = it->second.startDateTime();
+        // Note: for a relative order, the UTC time is sufficient and much faster
+        const QDateTime date = it->second.startDateTime(Qt::UTC);
         mruMap[id]= qMax( mruMap[id], date );
     }
     std::priority_queue<TaskWithLastUseDate> mruTasks;


### PR DESCRIPTION
Charm triggered thousands of reads to /etc/localtime on my machine
every few seconds, leading to periodic disk sleeps. Profiling
with strace -k and perf trace showed the culprits: Lots and lots
of QDateTime usage in the local time zone. The real hotspots can
easily be converted to use UTC instead, minimizing the required
conversions and thus the load on the hard disk.

Before, I easily ended up with ~18k reads to /etc/localtime every
5 seconds or so. Now, this value is down to less than 200.