### PR TITLE
Find Qt5Keychain includes in non-std location

### DIFF
--- a/Charm/CMakeLists.txt
+++ b/Charm/CMakeLists.txt
@@ -177,6 +177,9 @@ ADD_LIBRARY(
     ${CharmApplication_SRCS} ${UiGenerated_SRCS}
 )
 TARGET_LINK_LIBRARIES(CharmApplication ${CharmApplication_LIBS} ${QT_LIBRARIES})
+IF(QTKEYCHAIN_SYSTEM)
+    TARGET_INCLUDE_DIRECTORIES(CharmApplication PRIVATE ${QTKEYCHAIN_INCLUDE_DIRS})
+ENDIF()
 
 SET( Charm_SRCS Charm.cpp )
 


### PR DESCRIPTION
Fixes the build of Charm under KDE's Emerge tool

Change-Id: If265587e1dcd8c166f2edc5061fb51d439819585