### PR TITLE
Fix httpclient basic auth handling

### DIFF
--- a/Charm/HttpClient/HttpJob.cpp
+++ b/Charm/HttpClient/HttpJob.cpp
@@ -315,9 +315,11 @@ bool HttpJob::handle(QNetworkReply *reply)
 
 void HttpJob::authenticationRequired(QNetworkReply *, QAuthenticator *authenticator)
 {
-    authenticator->setUser(m_username);
-    authenticator->setPassword(m_password);
-    m_authenticationDoneAlready = true;
+    if (!m_authenticationDoneAlready) {
+        authenticator->setUser(m_username);
+        authenticator->setPassword(m_password);
+        m_authenticationDoneAlready = true;
+    }
 }
 
 void HttpJob::emitFinished()
@@ -340,10 +342,18 @@ void HttpJob::setErrorAndEmitFinished(int code, const QString& errorString)
 
 void HttpJob::setErrorFromReplyAndEmitFinished(QNetworkReply *reply)
 {
-    if (reply->error() == QNetworkReply::HostNotFoundError)
-        setErrorAndEmitFinished(HostNotFound, reply->errorString());
-    else
-        setErrorAndEmitFinished(SomethingWentWrong, reply->errorString());
+    m_authenticationDoneAlready = false;
+    switch (reply->error()) {
+        case QNetworkReply::HostNotFoundError:
+            setErrorAndEmitFinished(HostNotFound, reply->errorString());
+            break;
+        case QNetworkReply::AuthenticationRequiredError:
+            setErrorAndEmitFinished(AuthenticationFailed, reply->errorString());
+            break;
+        default:
+            setErrorAndEmitFinished(SomethingWentWrong, reply->errorString());
+            break;
+    }
 }
 
 #include "moc_HttpJob.cpp"


### PR DESCRIPTION
When using httpbasicauth and using a wrong password then
1) HttpJob::authenticationRequired will be called again
   to retry but cause of the asynchrnous nature of
   qkeychain its needed to let that one fail by not
   setting user+password again what then pops up the
   auth-dialog as expected.
2) HttpJob::setErrorFromReplyAndEmitFinished needs to
   proper handle QNetworkReply::AuthenticationRequiredError.