### PR TITLE
Feature: Arrow keys in Task Select filter

### DIFF
--- a/Charm/Widgets/SelectTaskDialog.h
+++ b/Charm/Widgets/SelectTaskDialog.h
@@ -70,6 +70,7 @@ Q_SIGNALS:
 protected:
     void showEvent(QShowEvent *event) override;
     void hideEvent(QHideEvent *event) override;
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
 private Q_SLOTS:
     void slotCurrentItemChanged(const QModelIndex &, const QModelIndex &);


### PR DESCRIPTION
Working on Linux, to allow use of vertical arrow keys within
filter to select within the treeView.

This means if there are several tasks shown from the filter,
you can select the relevant task without moving from the lineedit box.

I'm not sure how this works for OSX however as I believe the vertical
arrow keys act as Home/End.

I've submitted the pull request as a (partially) implemented feature request.