### PR TITLE
Activity Report print fixes

### DIFF
--- a/Charm/Widgets/ActivityReport.cpp
+++ b/Charm/Widgets/ActivityReport.cpp
@@ -332,7 +332,7 @@ void ActivityReport::slotUpdate()
         QString content = tr("Report for %1, from %2 to %3")
                           .arg(CONFIGURATION.user.name(),
                                m_properties.start.toString(Qt::TextDate),
-                               m_properties.end.toString(Qt::TextDate));
+                               m_properties.end.addDays(-1).toString(Qt::TextDate));
         QDomText text = doc.createTextNode(content);
         headline.appendChild(text);
         body.appendChild(headline);

--- a/Charm/Widgets/ActivityReport.h
+++ b/Charm/Widgets/ActivityReport.h
@@ -97,7 +97,7 @@ public:
     void setReportProperties(const ActivityReportConfigurationDialog::Properties &properties);
 
 private Q_SLOTS:
-    void slotLinkClicked(const QUrl &which);
+    void updateRange(int direction);
 
 private:
     void slotUpdate() override;

--- a/Charm/Widgets/ActivityReportConfigurationDialog.ui
+++ b/Charm/Widgets/ActivityReportConfigurationDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>386</width>
-    <height>296</height>
+    <width>643</width>
+    <height>407</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -168,7 +168,7 @@
            <string>(events that start before...)</string>
           </property>
           <property name="text">
-           <string>End date</string>
+           <string>End date (excluded)</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/Charm/Widgets/MonthlyTimesheet.cpp
+++ b/Charm/Widgets/MonthlyTimesheet.cpp
@@ -55,8 +55,12 @@ MonthlyTimeSheetReport::MonthlyTimeSheetReport(QWidget *parent)
         m_dailyhours = 8;
     }
 
-    connect(this, &MonthlyTimeSheetReport::anchorClicked,
-            this, &MonthlyTimeSheetReport::slotLinkClicked);
+    connect(this, &ReportPreviewWindow::nextClicked, this, [this] () {
+        updateRange(1);
+    });
+    connect(this, &ReportPreviewWindow::previousClicked, this, [this] () {
+        updateRange(-1);
+    });
 }
 
 MonthlyTimeSheetReport::~MonthlyTimeSheetReport()
@@ -178,6 +182,9 @@ void MonthlyTimeSheetReport::update()
         // store in minute map:
         m_secondsMap[event.taskId()] = seconds;
     }
+
+    setTimeSpanTypeName(tr("Month"));
+
     // now the reporting:
     // headline first:
     QTextDocument report;
@@ -204,16 +211,6 @@ void MonthlyTimeSheetReport::update()
         QDomText text = doc.createTextNode(content);
         headline.appendChild(text);
         body.appendChild(headline);
-        QDomElement previousLink = doc.createElement(QStringLiteral("a"));
-        previousLink.setAttribute(QStringLiteral("href"), QStringLiteral("Previous"));
-        QDomText previousLinkText = doc.createTextNode(tr("<Previous Month>"));
-        previousLink.appendChild(previousLinkText);
-        body.appendChild(previousLink);
-        QDomElement nextLink = doc.createElement(QStringLiteral("a"));
-        nextLink.setAttribute(QStringLiteral("href"), QStringLiteral("Next"));
-        QDomText nextLinkText = doc.createTextNode(tr("<Next Month>"));
-        nextLink.appendChild(nextLinkText);
-        body.appendChild(nextLink);
         QDomElement paragraph = doc.createElement(QStringLiteral("br"));
         body.appendChild(paragraph);
     }
@@ -306,11 +303,9 @@ void MonthlyTimeSheetReport::update()
     uploadButton()->setEnabled(false);
 }
 
-void MonthlyTimeSheetReport::slotLinkClicked(const QUrl &which)
+void MonthlyTimeSheetReport::updateRange(int deltaMonths)
 {
-    QDate start = which.toString()
-                  == QLatin1String("Previous") ? startDate().addMonths(-1) : startDate().addMonths(1);
-    QDate end = which.toString()
-                == QLatin1String("Previous") ? endDate().addMonths(-1) : endDate().addMonths(1);
+    QDate start = startDate().addMonths(deltaMonths);
+    QDate end = endDate().addMonths(deltaMonths);
     setReportProperties(start, end, rootTask(), activeTasksOnly());
 }

--- a/Charm/Widgets/MonthlyTimesheet.h
+++ b/Charm/Widgets/MonthlyTimesheet.h
@@ -42,7 +42,7 @@ public:
                              bool activeTasksOnly) override;
 
 private Q_SLOTS:
-    void slotLinkClicked(const QUrl &which);
+    void updateRange(int deltaMonths);
 
 private:
     QString suggestedFileName() const override;

--- a/Charm/Widgets/ReportPreviewWindow.cpp
+++ b/Charm/Widgets/ReportPreviewWindow.cpp
@@ -47,6 +47,10 @@ ReportPreviewWindow::ReportPreviewWindow(QWidget *parent)
             this, &ReportPreviewWindow::slotSaveToText);
     connect(m_ui->textBrowser, &QTextBrowser::anchorClicked,
             this, &ReportPreviewWindow::anchorClicked);
+    connect(m_ui->pushButtonNext, &QPushButton::clicked,
+            this, &ReportPreviewWindow::nextClicked);
+    connect(m_ui->pushButtonPrevious, &QPushButton::clicked,
+            this, &ReportPreviewWindow::previousClicked);
 #ifndef QT_NO_PRINTER
     connect(m_ui->pushButtonPrint, &QPushButton::clicked,
             this, &ReportPreviewWindow::slotPrint);
@@ -77,6 +81,12 @@ void ReportPreviewWindow::setDocument(const QTextDocument *document)
         m_ui->textBrowser->setDocument(nullptr);
         m_document.reset();
     }
+}
+
+void ReportPreviewWindow::setTimeSpanTypeName(const QString &name)
+{
+    m_ui->pushButtonPrevious->setText(tr("Previous %1").arg(name));
+    m_ui->pushButtonNext->setText(tr("Next %1").arg(name));
 }
 
 QDomDocument ReportPreviewWindow::createReportTemplate() const

--- a/Charm/Widgets/ReportPreviewWindow.h
+++ b/Charm/Widgets/ReportPreviewWindow.h
@@ -46,9 +46,12 @@ public:
 
 Q_SIGNALS:
     void anchorClicked(const QUrl &which);
+    void nextClicked();
+    void previousClicked();
 
 protected:
     void setDocument(const QTextDocument *document);
+    void setTimeSpanTypeName(const QString &name);
     QDomDocument createReportTemplate() const;
     QPushButton *saveToXmlButton() const;
     QPushButton *saveToTextButton() const;
@@ -66,6 +69,7 @@ private Q_SLOTS:
 private:
     QScopedPointer<Ui::ReportPreviewWindow> m_ui;
     QScopedPointer<QTextDocument> m_document;
+    QString m_timeSpanTypeName;
 };
 
 #endif

--- a/Charm/Widgets/ReportPreviewWindow.ui
+++ b/Charm/Widgets/ReportPreviewWindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>593</width>
-    <height>258</height>
+    <width>802</width>
+    <height>406</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -42,6 +42,20 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonPrevious">
+       <property name="text">
+        <string>Previous</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonNext">
+       <property name="text">
+        <string>Next</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonUpdate">

--- a/Charm/Widgets/WeeklyTimesheet.cpp
+++ b/Charm/Widgets/WeeklyTimesheet.cpp
@@ -266,7 +266,12 @@ WeeklyTimeSheetReport::WeeklyTimeSheetReport(QWidget *parent)
 {
     QPushButton *upload = uploadButton();
     connect(upload, &QPushButton::clicked, this, &WeeklyTimeSheetReport::slotUploadTimesheet);
-    connect(this, &ReportPreviewWindow::anchorClicked, this, &WeeklyTimeSheetReport::slotLinkClicked);
+    connect(this, &ReportPreviewWindow::nextClicked, this, [this] () {
+        updateRange(7);
+    });
+    connect(this, &ReportPreviewWindow::previousClicked, this, [this] () {
+        updateRange(-7);
+    });
 
     if (!Lotsofcake::Configuration().isConfigured())
         upload->hide();
@@ -347,6 +352,9 @@ void WeeklyTimeSheetReport::update()
         // store in minute map:
         m_secondsMap[event.taskId()] = seconds;
     }
+
+    setTimeSpanTypeName(tr("Week"));
+
     // now the reporting:
     // headline first:
     QTextDocument report;
@@ -371,16 +379,7 @@ void WeeklyTimeSheetReport::update()
         QDomText text = doc.createTextNode(content);
         headline.appendChild(text);
         body.appendChild(headline);
-        QDomElement previousLink = doc.createElement(QStringLiteral("a"));
-        previousLink.setAttribute(QStringLiteral("href"), QStringLiteral("Previous"));
-        QDomText previousLinkText = doc.createTextNode(tr("<Previous Week>"));
-        previousLink.appendChild(previousLinkText);
-        body.appendChild(previousLink);
-        QDomElement nextLink = doc.createElement(QStringLiteral("a"));
-        nextLink.setAttribute(QStringLiteral("href"), QStringLiteral("Next"));
-        QDomText nextLinkText = doc.createTextNode(tr("<Next Week>"));
-        nextLink.appendChild(nextLinkText);
-        body.appendChild(nextLink);
+
         QDomElement paragraph = doc.createElement(QStringLiteral("br"));
         body.appendChild(paragraph);
     }
@@ -571,11 +570,9 @@ QByteArray WeeklyTimeSheetReport::saveToText()
     return output;
 }
 
-void WeeklyTimeSheetReport::slotLinkClicked(const QUrl &which)
+void WeeklyTimeSheetReport::updateRange(int deltaDays)
 {
-    QDate start = which.toString()
-                  == QLatin1String("Previous") ? startDate().addDays(-7) : startDate().addDays(7);
-    QDate end = which.toString()
-                == QLatin1String("Previous") ? endDate().addDays(-7) : endDate().addDays(7);
+    QDate start = startDate().addDays(deltaDays);
+    QDate end = endDate().addDays(deltaDays);
     setReportProperties(start, end, rootTask(), activeTasksOnly());
 }

--- a/Charm/Widgets/WeeklyTimesheet.h
+++ b/Charm/Widgets/WeeklyTimesheet.h
@@ -86,7 +86,7 @@ public:
 private Q_SLOTS:
     void slotUploadTimesheet();
     void slotTimesheetUploaded(HttpJob *);
-    void slotLinkClicked(const QUrl &which);
+    void updateRange(int deltaDays);
 
 private:
     QString suggestedFileName() const override;

--- a/Core/Controller.cpp
+++ b/Core/Controller.cpp
@@ -261,7 +261,11 @@ void Controller::loadConfigValue(const QString &key, T &configValue) const
 void Controller::provideMetaData(Configuration &configuration)
 {
     Q_ASSERT_X(m_storage != nullptr, Q_FUNC_INFO, "No storage interface available");
-    configuration.user.setName(m_storage->getMetaData(MetaKey_Key_UserName));
+
+    const QString userName = m_storage->getMetaData(MetaKey_Key_UserName);
+    if (!userName.isEmpty()) {
+        configuration.user.setName(userName);
+    }
 
     loadConfigValue(MetaKey_Key_TimeTrackerFontSize, configuration.timeTrackerFontSize);
     loadConfigValue(MetaKey_Key_DurationFormat, configuration.durationFormat);


### PR DESCRIPTION
We are using Charm and Activity report (printing as PDF) internally in the company and had several issues with it:
* The user name disappeared from the report for several users, it seems a problem of the user name copy to and from the metadata, where sometimes it went blank. Now it checks explicitly for blank values in that cache
* The activity report header had wrong dates printed, as I do a report for "Last Month", the result says  1st May - 1st June, instead of 1st May - 31st May. Now the correct range appears
* In the final PDF, the <Previous Month><Next Month> links are visible, which make the printout look quite broken. Now the next/previous function is in outside pushbuttons