### PR TITLE
CMake: Use CMAKE_AUTOUIC

### DIFF
--- a/Charm/CMakeLists.txt
+++ b/Charm/CMakeLists.txt
@@ -142,8 +142,7 @@ IF( CHARM_IDLE_DETECTION )
     ENDIF()
 ENDIF()
 
-QT5_WRAP_UI(
-    UiGenerated_SRCS
+set(CharmUi_SRCS
     Widgets/CommentEditorPopup.ui
     Widgets/ConfigurationDialog.ui
     Widgets/CharmPreferences.ui
@@ -167,7 +166,7 @@ QT5_ADD_RESOURCES( Resources_SRCS CharmResources.qrc )
 
 ADD_LIBRARY(
     CharmApplication STATIC
-    ${CharmApplication_SRCS} ${UiGenerated_SRCS}
+    ${CharmApplication_SRCS} ${CharmUi_SRCS}
 )
 
 kde_target_enable_exceptions( CharmApplication PUBLIC )

--- a/cmake/ECM/kde-modules/KDECMakeSettings.cmake
+++ b/cmake/ECM/kde-modules/KDECMakeSettings.cmake
@@ -223,6 +223,7 @@ if(NOT KDE_SKIP_BUILD_SETTINGS)
    # Enable automoc in cmake
    # Since CMake 2.8.6
    set(CMAKE_AUTOMOC ON)
+   set(CMAKE_AUTOUIC ON)
 
    # By default, create 'GUI' executables. This can be reverted on a per-target basis
    # using ECMMarkNonGuiExecutable


### PR DESCRIPTION
CMake 3.20 changed the behavior of AUTOMOC in a subtle way
(https://gitlab.kitware.com/cmake/cmake/-/issues/21977) which
revealed a circular dependency between the autogen target and the
files generated by qt5_wrap_ui(). The circular dependency always
existed, but did not appear until CMake 3.20 due to a bug in Ninja
(https://github.com/ninja-build/ninja/issues/1251).

Resolve this issue by using AUTOUIC as well as AUTOMOC, and not
combining the CMake AUTOMOC approach with the Qt qt5_wrap_ui()
approach.